### PR TITLE
Fixes #11 - Py3K fix: Convert ranges to list

### DIFF
--- a/aldryn_common/paginator.py
+++ b/aldryn_common/paginator.py
@@ -248,7 +248,7 @@ class DiggPaginator(ExPaginator):
             main_range = [1, max(body, min(number+padding, main_range[1]))]
             main_range[0] = 1
         else:
-            leading = range(1, tail+1)
+            leading = list(range(1, tail+1))
         # basically same for trailing range, but not in ``left_align`` mode
         if self.align_left:
             trailing = []
@@ -264,7 +264,7 @@ class DiggPaginator(ExPaginator):
                 else:
                     main_range = [min(num_pages-body+1, max(number-padding, main_range[0])), num_pages]
             else:
-                trailing = range(num_pages-tail+1, num_pages+1)
+                trailing = list(range(num_pages-tail+1, num_pages+1))
 
         # finally, normalize values that are out of bound; this basically
         # fixes all the things the above code screwed up in the simple case


### PR DESCRIPTION
Handles this problem, tracked by issue #11:

```
Traceback (most recent call last):
  File "VENV/lib/python3.4/site-packages/django/core/handlers/base.py", line 111, in get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "VENV/lib/python3.4/site-packages/cms/utils/decorators.py", line 17, in inner
    return func(request, *args, **kwargs)
  File "VENV/lib/python3.4/site-packages/django/views/generic/base.py", line 69, in view
    return self.dispatch(request, *args, **kwargs)
  File "VENV/lib/python3.4/site-packages/django/views/generic/base.py", line 87, in dispatch
    return handler(request, *args, **kwargs)
  File "VENV/lib/python3.4/site-packages/aldryn_search/views.py", line 60, in get
    return super(AldrynSearchView, self).get(request, *args, **kwargs)
  File "VENV/lib/python3.4/site-packages/django/views/generic/list.py", line 160, in get
    context = self.get_context_data()
  File "VENV/lib/python3.4/site-packages/aldryn_search/views.py", line 80, in get_context_data
    context = super(AldrynSearchView, self).get_context_data(**kwargs)
  File "VENV/lib/python3.4/site-packages/django/views/generic/list.py", line 120, in get_context_data
    paginator, page, queryset, is_paginated = self.paginate_queryset(queryset, page_size)
  File "VENV/lib/python3.4/site-packages/django/views/generic/list.py", line 64, in paginate_queryset
    page = paginator.page(page_number)
  File "VENV/lib/python3.4/site-packages/aldryn_common/paginator.py", line 281, in page
    [page.leading_range, page.main_range, page.trailing_range])
  File "VENV/lib/python3.4/site-packages/aldryn_common/paginator.py", line 280, in <lambda>
    page.page_range = functools.reduce(lambda x, y: x+((x and y) and [False])+y,
TypeError: can only concatenate list (not "range") to list
```