### PR TITLE
Travis setup and badges

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,34 @@
+language: python
+python: 3.5
+
+# Use container based infrastructure
+sudo: false
+
+env:
+#  - TOX_ENV=flake8
+  - TOX_ENV=py35-dj19
+  - TOX_ENV=py35-dj18
+  - TOX_ENV=py34-dj19
+  - TOX_ENV=py34-dj18
+  - TOX_ENV=py33-dj19
+  - TOX_ENV=py33-dj18
+  - TOX_ENV=py27-dj19
+  - TOX_ENV=py27-dj18
+  - TOX_ENV=py34-dj17
+  - TOX_ENV=py33-dj17
+  - TOX_ENV=py27-dj17
+  - TOX_ENV=py33-dj16
+  - TOX_ENV=py27-dj16
+
+install:
+  - pip install --upgrade pip
+  - pip install tox coveralls
+
+script:
+  - tox -e $TOX_ENV
+
+after_success:
+  - coveralls
+
+notifications:
+  webhooks: http://addons.us-iad-rs.aldryn.io/en/travis-endpoint/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Aldryn Common
 
+![build status](https://img.shields.io/travis/aldryn/aldryn-common.svg) ![coverage](https://img.shields.io/coveralls/aldryn/aldryn-common.svg) ![PyPI version](https://img.shields.io/pypi/v/aldryn-common.svg)
+
 Aldryn Common is a library of helpful utilities for packages in the [Aldryn](http://aldryn.com) ecosystem, and is
 also aimed at developers of [django CMS](http://django-cms.org) projects.
 


### PR DESCRIPTION
Base python is set to 3.5. This is the simplest way to get it installed on Travis for now.