### PR TITLE
Bump django-sortedm2m version.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from aldryn_common import __version__
 
 REQUIREMENTS = [
     'aldryn-boilerplates',
-    'django-sortedm2m',
+    'django-sortedm2m>=1.2.2',
     'six',
 ]
 


### PR DESCRIPTION
This version of django-sortedm2m contains the fix for django 1.8+