### PR TITLE
adds compat module

### DIFF
--- a/aldryn_common/compat.py
+++ b/aldryn_common/compat.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+from distutils.version import LooseVersion
+
+import django
+
+
+# These means "less than or equal to DJANGO_FOO_BAR"
+DJANGO_1_6 = LooseVersion(django.get_version()) < LooseVersion('1.7')
+DJANGO_1_7 = LooseVersion(django.get_version()) < LooseVersion('1.8')
+DJANGO_1_8 = LooseVersion(django.get_version()) < LooseVersion('1.9')
+DJANGO_1_9 = LooseVersion(django.get_version()) < LooseVersion('2.0')


### PR DESCRIPTION
CMS 3.3 drops several of these compat variables.
I think this is a good opportunity the addons that rely on these to use aldryn-common as a bridge.