### PR TITLE
Relaxed sortedm2m version range

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from aldryn_common import __version__
 
 REQUIREMENTS = [
     'aldryn-boilerplates',
-    'django-sortedm2m>=1.2.2,<1.3',
+    'django-sortedm2m>=1.2.2,!=1.3.0,!=1.3.1',
     'six',
 ]
 


### PR DESCRIPTION
Version 1.3.0 of django-sortedm2m introduced a regression, which is
fixed in 1.3.2